### PR TITLE
feat: Adds booking API data structure

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -149,9 +149,11 @@ components:
           description: Reseller's channel, such as web, physical office, etc.
           type: string
     Customer:
-      oneOf:
-        - $ref: '#/components/schemas/CustomerWithPhone'
-        - $ref: '#/components/schemas/CustomerWithEmail'
+      allOf:
+        - $ref: '#/components/schemas/CustomerBase'
+        - anyOf:
+          - $ref: '#/components/schemas/CustomerWithPhone'
+          - $ref: '#/components/schemas/CustomerWithEmail'
     CustomerBase:
       description: Person responsible for this booking who should be contacted by the hotel if needed
       type: object
@@ -164,31 +166,29 @@ components:
           type: string
         surname:
           type: string
+        address:
+          $ref: https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/Address
+    CustomerWithPhone:
+      type: object
+      required:
+        - phone
+      properties:
         phone:
           description: Phone number (with country prefix)
           type: string
           maxLength: 18
           example: +44123456789
+    CustomerWithEmail:
+      type: object
+      required:
+        - email
+      properties:
         email:
           description: E-mail contact
           type: string
           format: email
           example: joseph.urban@example.com
           maxLength: 150
-        address:
-          $ref: https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/Address
-    CustomerWithPhone:
-      allOf:
-        - $ref: '#/components/schemas/CustomerBase'
-        - type: object
-          required:
-            - phone
-    CustomerWithEmail:
-      allOf:
-        - $ref: '#/components/schemas/CustomerBase'
-        - type: object
-          required:
-            - email
     RoomType:
       type: object
       required:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -74,17 +74,10 @@ components:
       type: object
       required:
         - customer
-        - reseller
         - hotelId
         - booking
         - pricing
       properties:
-        createdAt:
-          type: string
-          description: Date and time when the booking happened on the reseller's side.
-          format: date-time
-        reseller:
-          $ref: '#/components/schemas/Reseller'
         customer:
           $ref: '#/components/schemas/Customer'
         note:
@@ -99,7 +92,6 @@ components:
           required:
             - currency
             - total
-            - ratePlans
             - cancellationFees
           properties:
             currency:
@@ -108,8 +100,6 @@ components:
               description: Total price that should be paid. Including taxes - this is subject to change in the future.
               type: number
               format: float
-            ratePlans:
-              $ref: '#/components/schemas/RatePlans'
             # amenities
             cancellationFees:
               description: Under what conditions can this booking be cancelled and how much will it cost.
@@ -133,21 +123,6 @@ components:
                     format: float
         # billing: TBD (cash on arrival, card on arrival, online payment, crypto)
         # guarantee: TBD (can be for example credit card info)
-    Reseller:
-      description: Information about the party that made the booking possible
-      type: object
-      required:
-        - name
-      properties:
-        name:
-          description: Human readable name of the reseller
-          type: string
-        reference:
-          description: Reseller's reference (such as ID) to this particular booking
-          type: string
-        channel:
-          description: Reseller's channel, such as web, physical office, etc.
-          type: string
     Customer:
       allOf:
         - $ref: '#/components/schemas/CustomerBase'
@@ -189,7 +164,7 @@ components:
           format: email
           example: joseph.urban@example.com
           maxLength: 150
-    RoomType:
+    Room:
       type: object
       required:
         - id
@@ -209,7 +184,7 @@ components:
       required:
         - arrival
         - departure
-        - roomTypes
+        - rooms
         - guestInfo
       properties:
         arrival:
@@ -238,56 +213,11 @@ components:
               age:
                 description: Age at the time of arrival
                 type: number
-        roomTypes:
+        rooms:
           type: array
           description: List of rooms that form this booking. If a single room type is booked more than once, it shall be present more than once.
           items:
-            $ref: '#/components/schemas/RoomType'
-    RatePlans:
-      description: List of rate plans that form the total price.
-      type: array
-      items:
-        $ref: '#/components/schemas/RatePlan'
-    RatePlan:
-      type: object
-      required:
-        - id
-        - roomTypeId
-        - price
-        - from
-        - to
-        - guestInfoIds
-        - subtotal
-      properties:
-        id:
-          description: Rate plan ID as stated in the Hotel ratePlans document on WT
-          type: string
-        roomTypeId:
-          description: Room type ID as stated in the Hotel description document on WT
-          type: string
-        price:
-          description: Base price for this rate plan for one person and for one night
-          type: number
-          format: float
-        from:
-          description: The first date to which this rate plan applies.
-          type: string
-          format: date
-        to:
-          description: The last date to which this rate plan applies.
-          type: string
-          format: date
-        guestInfoIds:
-          type: array
-          items:
-            description: Which guests will be staying in this room? The strings should be id fields from guestInfo, so we can match the guests and their additional information when needed.
-            type: string
-        appliedModifier:
-          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/RatePlanPriceModifier'
-        subtotal:
-          description: The amount that this rate plan with this modifier adds to the overall price.
-          type: number
-          format: float
+            $ref: '#/components/schemas/Room'
 
     Error:
       title: Error

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -84,103 +84,16 @@ components:
           description: Date and time when the booking happened on the reseller's side.
           format: date-time
         reseller:
-          description: Information about the party that made the booking possible
-          type: object
-          required:
-            - name
-          properties:
-            name:
-              description: Human readable name of the reseller
-              type: string
-            reference:
-              description: Reseller's reference (such as ID) to this particular booking
-              type: string
-            channel:
-              description: Reseller's channel, such as web, physical office, etc.
-              type: string
+          $ref: '#/components/schemas/Reseller'
         customer:
-          description: Person responsible for this booking who should be contacted by the hotel if needed
-          type: object
-          required:
-            - name
-            - surname
-            - phone
-            - email
-            - address
-          properties:
-            name:
-              type: string
-            surname:
-              type: string
-            phone:
-              description: Phone number (with country prefix)
-              type: string
-              maxLength: 18
-              example: +44123456789
-            email:
-              description: E-mail contact
-              type: string
-              format: email
-              example: joseph.urban@example.com
-              maxLength: 150
-            address:
-              $ref: https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/Address
+          $ref: '#/components/schemas/Customer'
         note:
           description: Additional information passed to a hotel from a customer
           type: string
         hotelId:
           $ref: https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
         booking:
-          description: Information on the booked property
-          type: object
-          required:
-            - arrival
-            - departure
-            - numberOfGuests
-          properties:
-            arrival:
-              description: At what day will the people arrive
-              type: string
-              format: date
-            departure:
-              description: At what day will the people depart
-              type: string
-              format: date
-            numberOfGuests:
-              description: How many people will take part
-              type: number
-            guestInfo:
-              description: Additional information on every guest when required
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  surname:
-                    type: string
-                  age:
-                    description: Age at the time of arrival
-                    type: number
-            roomTypes:
-              type: array
-              description: List of rooms that form this booking. If a single room type is booked more than once, it shall be present more than once.
-              items:
-                type: object
-                required:
-                  - id
-                properties:
-                  id:
-                    description: Room type ID as stated in the Hotel description document on WT
-                    type: string
-                  numberOfGuests:
-                    description: To how many guests does this rate plan apply?
-                    type: number
-                  guests:
-                    type: array
-                    items:
-                      description: Which guests will be staying in this room? The numbers should be indices in guestInfo, so we can match the guests and their names and age.
-                      type: number
+          $ref: '#/components/schemas/BookingInfo'
         pricing:
           type: object
           required:
@@ -197,49 +110,9 @@ components:
               format: float
             ratePlans:
               description: List of rate plans that form the total price.
-              type: array
-              items:
-                type: object
-                required:
-                  - id
-                  - roomTypeId
-                  - price
-                  - from
-                  - to
-                  - subtotal
-                properties:
-                  id:
-                    description: Rate plan ID as stated in the Hotel ratePlans document on WT
-                    type: string
-                  roomTypeId:
-                    description: Room type ID as stated in the Hotel description document on WT
-                    type: string
-                  numberOfGuests:
-                    description: To how many guests does this rate plan apply?
-                    type: number
-                  guests:
-                    description: To which guests does this rate plan apply? The numbers should be indices in guestInfo, so we can match the guests and their names and age.
-                    type: array
-                    items:
-                      type: number
-                  price:
-                    description: Base price for this rate plan for one person and for one night
-                    type: number
-                    format: float
-                  from:
-                    description: The first date to which this rate plan applies.
-                    type: string
-                    format: date
-                  to:
-                    description: The last date to which this rate plan applies.
-                    type: string
-                    format: date
-                  appliedModifier:
-                    $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/RatePlanPriceModifier'
-                  subtotal:
-                    description: The amount that this rate plan with this modifier adds to the overall price.
-                    type: number
-                    format: float
+              oneOf:
+                - $ref: '#/components/schemas/RatePlansWithGuestInfo'
+                - $ref: '#/components/schemas/RatePlansWithNumberOfGuests'
             # amenities
             cancellationFees:
               description: Under what conditions can this booking be cancelled and how much will it cost.
@@ -263,6 +136,206 @@ components:
                     format: float
         # billing: TBD (cash on arrival, card on arrival, online payment, crypto)
         # guarantee: TBD (can be for example credit card info)
+    Reseller:
+      description: Information about the party that made the booking possible
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          description: Human readable name of the reseller
+          type: string
+        reference:
+          description: Reseller's reference (such as ID) to this particular booking
+          type: string
+        channel:
+          description: Reseller's channel, such as web, physical office, etc.
+          type: string
+    Customer:
+      description: Person responsible for this booking who should be contacted by the hotel if needed
+      type: object
+      required:
+        - name
+        - surname
+        - phone
+        - email
+        - address
+      properties:
+        name:
+          type: string
+        surname:
+          type: string
+        phone:
+          description: Phone number (with country prefix)
+          type: string
+          maxLength: 18
+          example: +44123456789
+        email:
+          description: E-mail contact
+          type: string
+          format: email
+          example: joseph.urban@example.com
+          maxLength: 150
+        address:
+          $ref: https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/Address
+    RoomTypeBase:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          description: Room type ID as stated in the Hotel description document on WT
+          type: string
+    RoomTypeWithGuestInfo:
+      type: object
+      required:
+        - guestInfo
+      allOf:
+        - $ref: '#/components/schemas/RoomTypeBase'
+        - type: object
+          properties:
+            guestInfo:
+              type: array
+              items:
+                description: Which guests will be staying in this room? The numbers should be indices in guestInfo, so we can match the guests and their names and age.
+                type: number
+    RoomTypeWithNumberOfGuests:
+      type: object
+      required:
+        - numberOfGuests
+      allOf:
+        - $ref: '#/components/schemas/RoomTypeBase'
+        - type: object
+          properties:
+            numberOfGuests:
+              description: To how many guests does this rate plan apply?
+              type: number
+    BookingInfoBase:
+      description: Information on the booked property
+      type: object
+      required:
+        - arrival
+        - departure
+        - roomTypes
+      properties:
+        arrival:
+          description: At what day will the people arrive
+          type: string
+          format: date
+        departure:
+          description: At what day will the people depart
+          type: string
+          format: date
+    BookingInfoWithGuestInfo:
+      type: object
+      required:
+        - guestInfo
+      allOf:
+        - $ref: '#/components/schemas/BookingInfoBase'
+        - type: object
+          properties:
+            guestInfo:
+              description: Additional information on every guest when required
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  surname:
+                    type: string
+                  age:
+                    description: Age at the time of arrival
+                    type: number
+            roomTypes:
+              type: array
+              description: List of rooms that form this booking. If a single room type is booked more than once, it shall be present more than once.
+              items:
+                $ref: '#/components/schemas/RoomTypeWithGuestInfo'
+    BookingInfoWithNumberOfGuests:
+      type: object
+      required:
+        - numberOfGuests
+      allOf:
+        - $ref: '#/components/schemas/BookingInfoBase'
+        - type: object
+          properties:
+            numberOfGuests:
+              description: How many people will take part
+              type: number
+            roomTypes:
+              type: array
+              description: List of rooms that form this booking. If a single room type is booked more than once, it shall be present more than once.
+              items:
+                $ref: '#/components/schemas/RoomTypeWithNumberOfGuests'
+    BookingInfo:
+      oneOf:
+        - $ref: '#/components/schemas/BookingInfoWithGuestInfo'
+        - $ref: '#/components/schemas/BookingInfoWithNumberOfGuests'
+    RatePlansWithGuestInfo:
+      type: array
+      items:
+        $ref: '#/components/schemas/RatePlanWithGuestInfo'
+    RatePlansWithNumberOfGuests:
+      type: array
+      items:
+        $ref: '#/components/schemas/RatePlanWithNumberOfGuests'
+    RatePlanBase:
+      type: object
+      required:
+        - id
+        - roomTypeId
+        - price
+        - from
+        - to
+        - subtotal
+      properties:
+        id:
+          description: Rate plan ID as stated in the Hotel ratePlans document on WT
+          type: string
+        roomTypeId:
+          description: Room type ID as stated in the Hotel description document on WT
+          type: string
+        price:
+          description: Base price for this rate plan for one person and for one night
+          type: number
+          format: float
+        from:
+          description: The first date to which this rate plan applies.
+          type: string
+          format: date
+        to:
+          description: The last date to which this rate plan applies.
+          type: string
+          format: date
+        appliedModifier:
+          $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/RatePlanPriceModifier'
+        subtotal:
+          description: The amount that this rate plan with this modifier adds to the overall price.
+          type: number
+          format: float
+    RatePlanWithGuestInfo:
+      allOf:
+        - $ref: '#/components/schemas/RatePlanBase'
+        - type: object
+          required:
+            - guestInfo
+          properties:
+            guestInfo:
+              description: To which guests does this rate plan apply? The numbers should be indices in guestInfo, so we can match the guests and their names and age.
+              type: array
+              items:
+                type: number
+    RatePlanWithNumberOfGuests:
+      allOf:
+        - $ref: '#/components/schemas/RatePlanBase'
+        - type: object
+          required:
+            - numberOfGuests
+          properties:
+            numberOfGuests:
+              description: To how many guests does this rate plan apply?
+              type: number
     Error:
       title: Error
       description: Default schema for errors returned by API.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -30,3 +30,193 @@ paths:
                   config:
                     type: string
                     description: Which config is the API using.
+  /booking:
+    post:
+      summary: Create booking
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Booking'
+      responses:
+        200:
+          description: Success
+        400:
+          $ref: '#/components/responses/BadRequestError'
+        409:
+          description: Booking cannot be executed, for example room types are not available anymore
+          $ref: '#/components/responses/ConflictError'
+components:
+  responses:
+    BadRequestError:
+      description: The server does not understand the request (HTTP code 400)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    ConflictError:
+      description: The server cannot process the request due to a conflicting inner state (HTTP code 409)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+  schemas:
+    Booking:
+      description: Booking object passed from a customer to a hotel
+      type: object
+      required:
+        - customer
+        - hotelId
+      properties:
+        createdAt:
+          type: string
+          description: Date and time when the booking happened on the reseller's side.
+          format: date-time
+        reseller:
+          description: Information about the party that enabled the booking
+          type: object
+          properties:
+            name:
+              description: Human readable name of the reseller
+              type: string
+            reference:
+              description: Reseller's reference (such as ID) to this particular booking
+              type: string
+            channel:
+              description: Reseller's channel, such as web, physical office, etc.
+              type: string
+        customer:
+          description: Person responsible for this booking
+          type: object
+          required:
+            - name
+            - surname
+            - phone
+            - email
+            - address
+          properties:
+            name:
+              type: string
+            surname:
+              type: string
+            phone:
+              description: Phone number (with country prefix)
+              type: string
+              maxLength: 18
+              example: +44123456789
+            email:
+              description: E-mail contact
+              type: string
+              format: email
+              example: joseph.urban@example.com
+              maxLength: 150
+            address:
+              $ref: https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/Address
+        note:
+          description: Additional information to a hotel from a customer
+          type: string
+        hotelId:
+          $ref: https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
+        booking:
+          description: Information on the booked property
+          type: object
+          properties:
+            arrival:
+              type: string
+              format: date
+            departure:
+              type: string
+              format: date
+            numberOfGuests:
+              type: number
+            guestInfo:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  surname:
+                    type: string
+                  age:
+                    type: number
+            roomTypes:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  guests:
+                    type: array
+                    items:
+                      type: number
+        pricing:
+          type: object
+          properties:
+            currency:
+              $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/CurrencyType'
+            total:
+              type: number
+              format: float
+            ratePlans:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  roomTypeId:
+                    type: string
+                  guests:
+                    type: array
+                    items:
+                      type: number
+                  price:
+                    type: number
+                    format: float
+                  from:
+                    type: string
+                    format: date
+                  to:
+                    type: string
+                    format: date
+                  appliedModifier:
+                    $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/RatePlanPriceModifier'
+                  subtotal:
+                    type: number
+                    format: float
+            # amenities
+        cancellationFees:
+          type: array
+          items:
+            type: object
+            properties:
+              from:
+                type: string
+                format: date
+              to:
+                type: string
+                format: date
+              amount:
+                type: number
+                format: float
+        # billing: TBD (cash on arrival, card on arrival, online payment, crypto)
+        # guarantee: TBD (can be for example credit card info)
+    Error:
+      title: Error
+      description: Default schema for errors returned by API.
+      properties:
+        status:
+          type: number
+          description: HTTP status
+        code:
+          type: string
+          description: Computer-readable error. Use this for comparison.
+        short:
+          type: string
+          description: Human-readable error with a short description of the error.
+        long:
+          type: string
+          description: Verbose explanation of what happened.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -41,7 +41,15 @@ paths:
               $ref: '#/components/schemas/Booking'
       responses:
         200:
-          description: Success
+          description: Booking was successfuly processed by the hotel
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    description: Hotel reference for this particular booking
+                    type: string
         400:
           $ref: '#/components/responses/BadRequestError'
         409:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -109,10 +109,7 @@ components:
               type: number
               format: float
             ratePlans:
-              description: List of rate plans that form the total price.
-              oneOf:
-                - $ref: '#/components/schemas/RatePlansWithGuestInfo'
-                - $ref: '#/components/schemas/RatePlansWithNumberOfGuests'
+              $ref: '#/components/schemas/RatePlans'
             # amenities
             cancellationFees:
               description: Under what conditions can this booking be cancelled and how much will it cost.
@@ -152,13 +149,15 @@ components:
           description: Reseller's channel, such as web, physical office, etc.
           type: string
     Customer:
+      oneOf:
+        - $ref: '#/components/schemas/CustomerWithPhone'
+        - $ref: '#/components/schemas/CustomerWithEmail'
+    CustomerBase:
       description: Person responsible for this booking who should be contacted by the hotel if needed
       type: object
       required:
         - name
         - surname
-        - phone
-        - email
         - address
       properties:
         name:
@@ -178,45 +177,40 @@ components:
           maxLength: 150
         address:
           $ref: https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/Address
-    RoomTypeBase:
+    CustomerWithPhone:
+      allOf:
+        - $ref: '#/components/schemas/CustomerBase'
+        - type: object
+          required:
+            - phone
+    CustomerWithEmail:
+      allOf:
+        - $ref: '#/components/schemas/CustomerBase'
+        - type: object
+          required:
+            - email
+    RoomType:
       type: object
       required:
         - id
+        - guestInfoIds
       properties:
         id:
           description: Room type ID as stated in the Hotel description document on WT
           type: string
-    RoomTypeWithGuestInfo:
-      type: object
-      required:
-        - guestInfo
-      allOf:
-        - $ref: '#/components/schemas/RoomTypeBase'
-        - type: object
-          properties:
-            guestInfo:
-              type: array
-              items:
-                description: Which guests will be staying in this room? The numbers should be indices in guestInfo, so we can match the guests and their names and age.
-                type: number
-    RoomTypeWithNumberOfGuests:
-      type: object
-      required:
-        - numberOfGuests
-      allOf:
-        - $ref: '#/components/schemas/RoomTypeBase'
-        - type: object
-          properties:
-            numberOfGuests:
-              description: To how many guests does this rate plan apply?
-              type: number
-    BookingInfoBase:
+        guestInfoIds:
+          type: array
+          items:
+            description: Which guests will be staying in this room? The strings should be id fields from guestInfo, so we can match the guests and their additional information when needed.
+            type: string
+    BookingInfo:
       description: Information on the booked property
       type: object
       required:
         - arrival
         - departure
         - roomTypes
+        - guestInfo
       properties:
         arrival:
           description: At what day will the people arrive
@@ -226,61 +220,35 @@ components:
           description: At what day will the people depart
           type: string
           format: date
-    BookingInfoWithGuestInfo:
-      type: object
-      required:
-        - guestInfo
-      allOf:
-        - $ref: '#/components/schemas/BookingInfoBase'
-        - type: object
-          properties:
-            guestInfo:
-              description: Additional information on every guest when required
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  surname:
-                    type: string
-                  age:
-                    description: Age at the time of arrival
-                    type: number
-            roomTypes:
-              type: array
-              description: List of rooms that form this booking. If a single room type is booked more than once, it shall be present more than once.
-              items:
-                $ref: '#/components/schemas/RoomTypeWithGuestInfo'
-    BookingInfoWithNumberOfGuests:
-      type: object
-      required:
-        - numberOfGuests
-      allOf:
-        - $ref: '#/components/schemas/BookingInfoBase'
-        - type: object
-          properties:
-            numberOfGuests:
-              description: How many people will take part
-              type: number
-            roomTypes:
-              type: array
-              description: List of rooms that form this booking. If a single room type is booked more than once, it shall be present more than once.
-              items:
-                $ref: '#/components/schemas/RoomTypeWithNumberOfGuests'
-    BookingInfo:
-      oneOf:
-        - $ref: '#/components/schemas/BookingInfoWithGuestInfo'
-        - $ref: '#/components/schemas/BookingInfoWithNumberOfGuests'
-    RatePlansWithGuestInfo:
+        guestInfo:
+          description: Additional information on every guest when required
+          type: array
+          items:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                description: Unique identifier for every guest, it can for example be a numerical ordinal. Every booking originator has to generate this data as it's used as a base for all other guest-related information (such as total number of guests).
+                type: string
+              name:
+                type: string
+              surname:
+                type: string
+              age:
+                description: Age at the time of arrival
+                type: number
+        roomTypes:
+          type: array
+          description: List of rooms that form this booking. If a single room type is booked more than once, it shall be present more than once.
+          items:
+            $ref: '#/components/schemas/RoomType'
+    RatePlans:
+      description: List of rate plans that form the total price.
       type: array
       items:
-        $ref: '#/components/schemas/RatePlanWithGuestInfo'
-    RatePlansWithNumberOfGuests:
-      type: array
-      items:
-        $ref: '#/components/schemas/RatePlanWithNumberOfGuests'
-    RatePlanBase:
+        $ref: '#/components/schemas/RatePlan'
+    RatePlan:
       type: object
       required:
         - id
@@ -288,6 +256,7 @@ components:
         - price
         - from
         - to
+        - guestInfoIds
         - subtotal
       properties:
         id:
@@ -308,34 +277,18 @@ components:
           description: The last date to which this rate plan applies.
           type: string
           format: date
+        guestInfoIds:
+          type: array
+          items:
+            description: Which guests will be staying in this room? The strings should be id fields from guestInfo, so we can match the guests and their additional information when needed.
+            type: string
         appliedModifier:
           $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/RatePlanPriceModifier'
         subtotal:
           description: The amount that this rate plan with this modifier adds to the overall price.
           type: number
           format: float
-    RatePlanWithGuestInfo:
-      allOf:
-        - $ref: '#/components/schemas/RatePlanBase'
-        - type: object
-          required:
-            - guestInfo
-          properties:
-            guestInfo:
-              description: To which guests does this rate plan apply? The numbers should be indices in guestInfo, so we can match the guests and their names and age.
-              type: array
-              items:
-                type: number
-    RatePlanWithNumberOfGuests:
-      allOf:
-        - $ref: '#/components/schemas/RatePlanBase'
-        - type: object
-          required:
-            - numberOfGuests
-          properties:
-            numberOfGuests:
-              description: To how many guests does this rate plan apply?
-              type: number
+
     Error:
       title: Error
       description: Default schema for errors returned by API.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -45,8 +45,9 @@ paths:
         400:
           $ref: '#/components/responses/BadRequestError'
         409:
-          description: Booking cannot be executed, for example room types are not available anymore
           $ref: '#/components/responses/ConflictError'
+        422:
+          $ref: '#/components/responses/UnprocessableEntityError'
 components:
   responses:
     BadRequestError:
@@ -56,7 +57,13 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
     ConflictError:
-      description: The server cannot process the request due to a conflicting inner state (HTTP code 409)
+      description: Booking cannot be executed, for example room types are not available anymore (HTTP code 409)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    UnprocessableEntityError:
+      description: Request body or params validation failed.
       content:
         application/json:
           schema:
@@ -67,15 +74,20 @@ components:
       type: object
       required:
         - customer
+        - reseller
         - hotelId
+        - booking
+        - pricing
       properties:
         createdAt:
           type: string
           description: Date and time when the booking happened on the reseller's side.
           format: date-time
         reseller:
-          description: Information about the party that enabled the booking
+          description: Information about the party that made the booking possible
           type: object
+          required:
+            - name
           properties:
             name:
               description: Human readable name of the reseller
@@ -87,7 +99,7 @@ components:
               description: Reseller's channel, such as web, physical office, etc.
               type: string
         customer:
-          description: Person responsible for this booking
+          description: Person responsible for this booking who should be contacted by the hotel if needed
           type: object
           required:
             - name
@@ -114,23 +126,31 @@ components:
             address:
               $ref: https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/Address
         note:
-          description: Additional information to a hotel from a customer
+          description: Additional information passed to a hotel from a customer
           type: string
         hotelId:
           $ref: https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType
         booking:
           description: Information on the booked property
           type: object
+          required:
+            - arrival
+            - departure
+            - numberOfGuests
           properties:
             arrival:
+              description: At what day will the people arrive
               type: string
               format: date
             departure:
+              description: At what day will the people depart
               type: string
               format: date
             numberOfGuests:
+              description: How many people will take part
               type: number
             guestInfo:
+              description: Additional information on every guest when required
               type: array
               items:
                 type: object
@@ -140,68 +160,107 @@ components:
                   surname:
                     type: string
                   age:
+                    description: Age at the time of arrival
                     type: number
             roomTypes:
               type: array
+              description: List of rooms that form this booking. If a single room type is booked more than once, it shall be present more than once.
               items:
                 type: object
+                required:
+                  - id
                 properties:
                   id:
+                    description: Room type ID as stated in the Hotel description document on WT
                     type: string
+                  numberOfGuests:
+                    description: To how many guests does this rate plan apply?
+                    type: number
                   guests:
                     type: array
                     items:
+                      description: Which guests will be staying in this room? The numbers should be indices in guestInfo, so we can match the guests and their names and age.
                       type: number
         pricing:
           type: object
+          required:
+            - currency
+            - total
+            - ratePlans
+            - cancellationFees
           properties:
             currency:
               $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/CurrencyType'
             total:
+              description: Total price that should be paid. Including taxes - this is subject to change in the future.
               type: number
               format: float
             ratePlans:
+              description: List of rate plans that form the total price.
               type: array
               items:
                 type: object
+                required:
+                  - id
+                  - roomTypeId
+                  - price
+                  - from
+                  - to
+                  - subtotal
                 properties:
                   id:
+                    description: Rate plan ID as stated in the Hotel ratePlans document on WT
                     type: string
                   roomTypeId:
+                    description: Room type ID as stated in the Hotel description document on WT
                     type: string
+                  numberOfGuests:
+                    description: To how many guests does this rate plan apply?
+                    type: number
                   guests:
+                    description: To which guests does this rate plan apply? The numbers should be indices in guestInfo, so we can match the guests and their names and age.
                     type: array
                     items:
                       type: number
                   price:
+                    description: Base price for this rate plan for one person and for one night
                     type: number
                     format: float
                   from:
+                    description: The first date to which this rate plan applies.
                     type: string
                     format: date
                   to:
+                    description: The last date to which this rate plan applies.
                     type: string
                     format: date
                   appliedModifier:
                     $ref: 'https://raw.githubusercontent.com/windingtree/wiki/ac6c33d38a9f91aa4b951a00acacf11905208550/hotel-data-swagger.yaml#/components/schemas/RatePlanPriceModifier'
                   subtotal:
+                    description: The amount that this rate plan with this modifier adds to the overall price.
                     type: number
                     format: float
             # amenities
-        cancellationFees:
-          type: array
-          items:
-            type: object
-            properties:
-              from:
-                type: string
-                format: date
-              to:
-                type: string
-                format: date
-              amount:
-                type: number
-                format: float
+            cancellationFees:
+              description: Under what conditions can this booking be cancelled and how much will it cost.
+              type: array
+              items:
+                type: object
+                required:
+                  - amount
+                properties:
+                  from:
+                    description: After which date does this cancellation fee apply (including). If not present, this policy applies since the beginning of time.
+                    type: string
+                    format: date
+                  to:
+                    description: Before which date does this cancellation policy apply (including). If not present, this policy applies until the time of arrival.
+                    type: string
+                    format: date
+                  amount:
+                    description: Cost of cancellation in percents of the final price, 100 means non refundable. This means how much money will the hotel keep.
+                    type: number
+                    format: float
         # billing: TBD (cash on arrival, card on arrival, online payment, crypto)
         # guarantee: TBD (can be for example credit card info)
     Error:


### PR DESCRIPTION
This PR aims to flesh out the booking data structure. It will get polished a bit (mandatory fields, descriptions etc.), the general idea will remain the same though. The latest version should be visible on https://app.swaggerhub.com/apis-docs/jirkachadima/wt-booking-api/will-be-set-at-runtime

**What is missing:**

- paid amenities or additional paid services
- billing information
- guarantee

@hynek-urban @czervenka Am I missing something important?

**TODO**

- [x] simplify the whole structure a bit by introducing guestInfo's id field
- [x] make either phone or email exclusive
- [ ] success response format